### PR TITLE
Update style.js to new HA 20251105

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -28,6 +28,7 @@ const style = css`
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-left: 1em;
   }
 
   .light-entity-card__header {
@@ -88,7 +89,7 @@ const style = css`
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-right: 0.5em;
+    margin-right: 1em;
   }
 `;
 

--- a/src/style.js
+++ b/src/style.js
@@ -77,6 +77,7 @@ const style = css`
     display: flex;
     justify-content: center;
     cursor: pointer;
+    align-items: center;
   }
 
   .hidden {
@@ -87,6 +88,7 @@ const style = css`
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-right: 0.5em;
   }
 `;
 


### PR DESCRIPTION
When I updated, seems the styling broke for me for the icons.
```
Installation method: Home Assistant OS
Core 2025.11.3
Supervisor 2025.11.5
Operating System 16.3
Frontend 20251105.1
```

Before:
<img width="401" height="774" alt="screenshot-2025-11-28_22-16-38" src="https://github.com/user-attachments/assets/0e59ebe9-660c-4fb8-bd3d-1691b1835641" /> <img width="514" height="347" alt="screenshot-2025-11-28_22-47-11" src="https://github.com/user-attachments/assets/59eca239-f815-4980-93ca-e9979dfa9eed" />



After with this fix (tried to keep it minimal)
<img width="480" height="396" alt="screenshot-2025-11-28_22-44-10" src="https://github.com/user-attachments/assets/cc0a23b2-c48b-42ec-b229-1e2da4061e6c" /> <img width="526" height="353" alt="screenshot-2025-11-28_22-44-00" src="https://github.com/user-attachments/assets/27ad0a24-e74b-4efd-9be4-ebf886c6e241" />



I manually edited my local copy of `light-entity-card.js`, and then copied those changes back to the repo. I am not sure how to build the final .js file, but I assume there is a way? Feel free to commit directly. Thanks again for the project.
